### PR TITLE
retry install pip more

### DIFF
--- a/tools/install_pip.sh
+++ b/tools/install_pip.sh
@@ -84,7 +84,7 @@ function install_get_pip {
             timecond="-z $LOCAL_PIP"
         fi
 
-        curl -f --retry 6 --retry-delay 5 \
+        curl -f --max-time 5 --retry 20 --retry-delay 5 \
             $timecond -o $LOCAL_PIP $PIP_GET_PIP_URL || \
             die $LINENO "Download of get-pip.py failed"
         touch $LOCAL_PIP.downloaded


### PR DESCRIPTION
sometimes this happens:
```
+ tools/install_pip.sh:install_get_pip:82  :   local timecond=
+ tools/install_pip.sh:install_get_pip:83  :   [[ -r /opt/devstack/files/get-pip.py ]]
+ tools/install_pip.sh:install_get_pip:84  :   timecond='-z /opt/devstack/files/get-pip.py'
+ tools/install_pip.sh:install_get_pip:87  :   curl -f --retry 6 --retry-delay 5 -z /opt/devstack/files/get-pip.py -o /opt/devstack/files/get-pip.py https://bootstrap.pypa.io/get-pip.py
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:02:08 --:--:--     0curl: (7) Failed to connect to bootstrap.pypa.io port 443: Connection timed out
+ tools/install_pip.sh:install_get_pip:89  :   die 89 'Download of get-pip.py failed'
+ functions-common:die:195                 :   local exitcode=7
+ functions-common:die:196                 :   set +o xtrace
```